### PR TITLE
Add missing include in src/main.cpp

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include <regex>
 #include <thread>
 #include <climits>
+#include <cstring>
 #include "magic_bitboards.h"
 #include "eval.h"
 #include "movegen.h"


### PR DESCRIPTION
strcmp() is used without including \<cstring\>, causing a build failure on Ubuntu 23.04. Fix this.

Fixes #4

**

With this fix, I'm able to compile and bench mr_bob successfully:

```
% ./bob bench
Mr Bob v1.2.0 UCI chess engine by Vincent Yu
NNUE loaded: nets/bob_brain-020322e184.nnue
Bench [#  1]       213239 nodes  2268500 nps       29 CP
Bench [#  2]       325320 nodes  2198108 nps       83 CP
Bench [#  3]       115645 nodes  2409270 nps      121 CP
Bench [#  4]        12159 nodes  2431800 nps        1 CP
Bench [#  5]        41205 nodes  3433750 nps      241 CP
Bench [#  6]        87650 nodes  2306579 nps       -1 CP
Bench [#  7]       391798 nodes  2251712 nps       39 CP
Bench [#  8]       249262 nodes  2225553 nps       -1 CP
Bench [#  9]       726246 nodes  2241500 nps       79 CP
Bench [# 10]       145694 nodes  2349903 nps     -355 CP
Bench [# 11]       263255 nodes  2289174 nps      152 CP
Bench [# 12]       724675 nodes  2209375 nps      227 CP
Bench [# 13]       215988 nodes  2226680 nps       60 CP
Bench [# 14]       381549 nodes  2167892 nps       54 CP
Bench [# 15]       280058 nodes  2222682 nps     -106 CP
Bench [# 16]        34782 nodes  3162000 nps      -37 CP
Bench [# 17]       165536 nodes  2236973 nps       85 CP
Bench [# 18]       736963 nodes  2093644 nps     -232 CP
Bench [# 19]       225354 nodes  2503933 nps       27 CP
Bench [# 20]       187722 nodes  2182814 nps       79 CP
Bench [# 21]      1432272 nodes  2147334 nps     -612 CP
Bench [# 22]       443425 nodes  2101540 nps        8 CP
Bench [# 23]       446158 nodes  2075153 nps      124 CP
Bench [# 24]       201485 nodes  2143457 nps      201 CP
Bench [# 25]       177804 nodes  2279538 nps       -5 CP
Bench [# 26]        44830 nodes  2988666 nps       -1 CP
Bench [# 27]       254095 nodes  2099958 nps       65 CP
Bench [# 28]       340215 nodes  2139717 nps      171 CP
Bench [# 29]       126695 nodes  2436442 nps      218 CP
Bench [# 30]        63542 nodes  2647583 nps      211 CP
Bench [# 31]       117429 nodes  2668841 nps      153 CP
Bench [# 32]       166392 nodes  2446941 nps      141 CP
Bench [# 33]        77551 nodes  2501645 nps       81 CP
Bench [# 34]        85734 nodes  2521588 nps      117 CP
Bench [# 35]        38440 nodes  2745714 nps      198 CP
Bench [# 36]       146314 nodes  2760641 nps      496 CP
Bench [# 37]        61588 nodes  2799454 nps      767 CP
Bench [# 38]        88310 nodes  2848709 nps     1202 CP
Bench [# 39]       257399 nodes  2181347 nps       67 CP
Bench [# 40]       218022 nodes  2202242 nps       77 CP
Bench [# 41]       288206 nodes  2150791 nps       82 CP
Bench [# 42]        98810 nodes  2533589 nps      137 CP
Bench [# 43]       245076 nodes  2753663 nps       37 CP
Bench [# 44]       263214 nodes  2157491 nps       99 CP
Bench [# 45]       169609 nodes  2146949 nps        1 CP
Bench [# 46]       175803 nodes  2313197 nps      134 CP
Bench [# 47]       224481 nodes  2200794 nps       27 CP
Bench [# 48]       285757 nodes  2148548 nps       48 CP
Bench [# 49]       317420 nodes  2204305 nps      127 CP
Bench [# 50]       156492 nodes  2407569 nps      288 CP
OVERALL:                                              12536668 nodes  2256419 nps
```
